### PR TITLE
fix: When the root node has only one child node and the child nodes are disabled, the root node will be selected by default

### DIFF
--- a/src/check.ts
+++ b/src/check.ts
@@ -166,6 +166,9 @@ export function getCheckedKeys<R, G, I> (
         TreeNode<R, G, I>
         >) {
           const childKey = childNode.key
+          if (levelTreeNode.children?.length === 1 && childNode.disabled) {
+            fullyChecked = false
+          }
           if (childNode.disabled) continue
           if (syntheticCheckedKeySet.has(childKey)) {
             partialChecked = true


### PR DESCRIPTION
ref [#803](https://github.com/TuSimple/naive-ui/issues/803)